### PR TITLE
Add -end method to dismiss MPCoachMarks programatically

### DIFF
--- a/MPCoachMarks/MPCoachMarks.h
+++ b/MPCoachMarks/MPCoachMarks.h
@@ -87,6 +87,7 @@ typedef NS_ENUM(NSInteger, ContinueLocation) {
 
 - (id)initWithFrame:(CGRect)frame coachMarks:(NSArray *)marks;
 - (void)start;
+- (void)end;
 
 @end
 

--- a/MPCoachMarks/MPCoachMarks.m
+++ b/MPCoachMarks/MPCoachMarks.m
@@ -195,13 +195,17 @@ NSString *const kContinueLabelText = @"Tap to continue";
                      }];
 }
 
+- (void)end {
+    [self cleanup:NO];
+}
+
 - (void)skipCoach {
     [self goToCoachMarkIndexed:self.coachMarks.count];
 }
 
 - (void)handleSingleTap:(UITapGestureRecognizer *)recognizer {
     [self.delegate coachMarksViewDidClicked:self atIndex:markIndex];
-    [self cleanup];
+    [self cleanup:YES];
 }
 
 - (UIImage*)fetchImage:(NSString*)name {
@@ -217,7 +221,7 @@ NSString *const kContinueLabelText = @"Tap to continue";
 - (void)goToCoachMarkIndexed:(NSUInteger)index {
     // Out of bounds
     if (index >= self.coachMarks.count) {
-        [self cleanup];
+        [self cleanup:YES];
         return;
     }
     
@@ -433,14 +437,19 @@ NSString *const kContinueLabelText = @"Tap to continue";
 
 #pragma mark - Cleanup
 
-- (void)cleanup {
+- (void)cleanup:(BOOL)animated {
     // Delegate (coachMarksViewWillCleanup:)
     if ([self.delegate respondsToSelector:@selector(coachMarksViewWillCleanup:)]) {
         [self.delegate coachMarksViewWillCleanup:self];
     }
-    
+    CGFloat duration;
+    if (animated) {
+        duration = self.animationDuration;
+    } else {
+        duration = 0.0;
+    }
     // Fade out self
-    [UIView animateWithDuration:self.animationDuration
+    [UIView animateWithDuration:duration
                      animations:^{
                          self.alpha = 0.0f;
                      }


### PR DESCRIPTION
Added -end method to programatically close the view.
Added :animated to private cleanup method to allow some control over ending the view.

This PR allows users to dismiss the view programatically. I added this because the view doesn't current support rotation and needed a way to get rid of it when my view rotates.
