### PR TITLE
fix(btnSkipCoach): prevent duplicate skip buttons from being added to view

### DIFF
--- a/MPCoachMarks/MPCoachMarks.m
+++ b/MPCoachMarks/MPCoachMarks.m
@@ -413,7 +413,7 @@ NSString *const kContinueLabelText = @"Tap to continue";
         }
     }
     
-    if (self.enableSkipButton) {
+    if (self.enableSkipButton && markIndex == 0) {
         btnSkipCoach = [[UIButton alloc] initWithFrame:(CGRect){{lblContinueWidth, [self yOriginForContinueLabel]}, {btnSkipWidth, 30.0f}}];
         [btnSkipCoach addTarget:self action:@selector(skipCoach) forControlEvents:UIControlEventTouchUpInside];
         [btnSkipCoach setTitle:self.skipButtonText forState:UIControlStateNormal];


### PR DESCRIPTION
Currently the skip button would get added over/over on top of itself at each step. This prevents that.
Thanks for a great CocoaPod. 👍 
