### PR TITLE
Fix MPCoachMarks retain cycle

### DIFF
--- a/MPCoachMarks/MPCoachMarks.m
+++ b/MPCoachMarks/MPCoachMarks.m
@@ -157,8 +157,6 @@ NSString *const kContinueLabelText = @"Tap to continue";
     anim.delegate = self;
     anim.timingFunction = [CAMediaTimingFunction functionWithName:kCAMediaTimingFunctionEaseOut];
     anim.duration = self.animationDuration;
-    anim.removedOnCompletion = NO;
-    anim.fillMode = kCAFillModeForwards;
     anim.fromValue = (__bridge id)(mask.path);
     anim.toValue = (__bridge id)(maskPath.CGPath);
     [mask addAnimation:anim forKey:@"path"];


### PR DESCRIPTION
The CABasicAnimation’s delegate is a strong reference to self and by not removing the animation on completion, it creates a retain cycle.

Since we correctly set the layer’s final path, there isn’t a reason to keep the animation around after it finishes. We can just have the animation automatically cleaned up after it completes to break the retain cycle.