### PR TITLE
Fix positioning of continue label on iPhone X

### DIFF
--- a/Example/Example/MPCoachMarks/MPCoachMarks.m
+++ b/Example/Example/MPCoachMarks/MPCoachMarks.m
@@ -20,6 +20,12 @@ static const BOOL kEnableSkipButton = YES;
 NSString *const kSkipButtonText = @"Skip";
 NSString *const kContinueLabelText = @"Tap to continue";
 
+@interface MPCoachMarks()
+#ifdef __IPHONE_11_0
+-(UIEdgeInsets)getSafeAreaInsets;
+#endif
+@end
+
 @implementation MPCoachMarks {
     CAShapeLayer *mask;
     NSUInteger markIndex;
@@ -421,15 +427,41 @@ NSString *const kContinueLabelText = @"Tap to continue";
 }
 
 - (CGFloat)yOriginForContinueLabel {
+    float topOffset = 20.0f;
+    float bottomOffset = 30.f;
+
+#ifdef __IPHONE_11_0
+    UIEdgeInsets safeInsets = [self getSafeAreaInsets];
+    topOffset += safeInsets.top;
+    bottomOffset += safeInsets.bottom;
+#endif
+
     switch (self.continueLocation) {
         case LOCATION_TOP:
-            return 20.0f;
+            return topOffset;
         case LOCATION_CENTER:
             return self.bounds.size.height / 2 - 15.0f;
         default:
-            return self.bounds.size.height - 30.0f;
+            return self.bounds.size.height - bottomOffset;
     }
 }
+
+#ifdef __IPHONE_11_0
+-(UIEdgeInsets)getSafeAreaInsets {
+    UIEdgeInsets safeInsets = { .top = 0, .bottom = 0, .left = 0, .right = 0 };
+    SEL selector = @selector(safeAreaInsets);
+    if ([self respondsToSelector:selector])
+    {
+        NSInvocation* invocation = [NSInvocation invocationWithMethodSignature:[self methodSignatureForSelector:selector]];
+        invocation.selector = selector;
+        invocation.target = self;
+        [invocation invoke];
+
+        [invocation getReturnValue:&safeInsets];
+    }
+    return safeInsets;
+}
+#endif
 
 #pragma mark - Cleanup
 

--- a/MPCoachMarks/MPCoachMarks.m
+++ b/MPCoachMarks/MPCoachMarks.m
@@ -20,6 +20,12 @@ static const BOOL kEnableSkipButton = YES;
 NSString *const kSkipButtonText = @"Skip";
 NSString *const kContinueLabelText = @"Tap to continue";
 
+@interface MPCoachMarks()
+#ifdef __IPHONE_11_0
+-(UIEdgeInsets)getSafeAreaInsets;
+#endif
+@end
+
 @implementation MPCoachMarks {
     CAShapeLayer *mask;
     NSUInteger markIndex;
@@ -428,15 +434,41 @@ NSString *const kContinueLabelText = @"Tap to continue";
 }
 
 - (CGFloat)yOriginForContinueLabel {
+    float topOffset = 20.0f;
+    float bottomOffset = 30.f;
+
+#ifdef __IPHONE_11_0
+    UIEdgeInsets safeInsets = [self getSafeAreaInsets];
+    topOffset += safeInsets.top;
+    bottomOffset += safeInsets.bottom;
+#endif
+
     switch (self.continueLocation) {
         case LOCATION_TOP:
-            return 20.0f;
+            return topOffset;
         case LOCATION_CENTER:
             return self.bounds.size.height / 2 - 15.0f;
         default:
-            return self.bounds.size.height - 30.0f;
+            return self.bounds.size.height - bottomOffset;
     }
 }
+
+#ifdef __IPHONE_11_0
+-(UIEdgeInsets)getSafeAreaInsets {
+    UIEdgeInsets safeInsets = { .top = 0, .bottom = 0, .left = 0, .right = 0 };
+    SEL selector = @selector(safeAreaInsets);
+    if ([self respondsToSelector:selector])
+    {
+        NSInvocation* invocation = [NSInvocation invocationWithMethodSignature:[self methodSignatureForSelector:selector]];
+        invocation.selector = selector;
+        invocation.target = self;
+        [invocation invoke];
+
+        [invocation getReturnValue:&safeInsets];
+    }
+    return safeInsets;
+}
+#endif
 
 #pragma mark - Cleanup
 


### PR DESCRIPTION
On the iPhone X simulator, the continue label is clipped by the "notch" when displayed at the top and overlaps the home bar at the bottom.

Here is the unmodified example app running on the iPhone X simulator:

![image](https://user-images.githubusercontent.com/481406/31311659-e2b4cd28-ab7e-11e7-9a84-d8ee1895e93b.png)

This PR adds support for UIKit's new safe area insets. If built with the iOS 11 SDK, and running on a version of iOS that supports `UIView safeAreaInsets`, the code will adjust the position of the continue label to avoid these collisions.

Here's the example app with this fix:

![image](https://user-images.githubusercontent.com/481406/31311647-ae2b0efa-ab7e-11e7-88c2-a663001cab2f.png)

Also, I noticed that the two copies of `MPCoachMarks.m` - `Example/Example/MPCoachMarks/MPCoachMarks.m` and `MPCoachMarks/MPCoachMarks.m` are slightly different. I've made this fix in both files.